### PR TITLE
Handle unset PYTHONPATH in Jenkins Pytest stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
             fi
 
             # 5) PYTHONPATH, чтобы импорты из подкаталогов находились
-            export PYTHONPATH="$PYTHONPATH:/repo:/repo/src:/repo/flask_city_council"
+            export PYTHONPATH="${PYTHONPATH:-}:/repo:/repo/src:/repo/flask_city_council"
 
             # 6) Запуск тестов с покрытием (по возможности)
             #    Если tests/ есть — используем его как цель, иначе пустим pytest по умолчанию.


### PR DESCRIPTION
## Summary
- guard the Jenkins Pytest stage PYTHONPATH export so it works even when the variable is unset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f8cc9103fc832e9189b1019ca94908