### PR TITLE
Handle unset PYTHONPATH in Jenkins Pytest stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,7 @@ pipeline {
             if [ -f requirements.txt ]; then
               pip install --no-cache-dir -r requirements.txt
             else
-              pip install --no-cache-dir pytest pytest-flask coverage
+              pip install --no-cache-dir pytest pytest-flask pytest-cov coverage
             fi
 
             # 3) Динамически формируем список пакетов/каталогов для покрытия
@@ -100,7 +100,7 @@ pipeline {
             fi
 
             # 5) PYTHONPATH, чтобы импорты из подкаталогов находились
-            export PYTHONPATH="$PYTHONPATH:/repo:/repo/src:/repo/flask_city_council"
+            export PYTHONPATH="${PYTHONPATH:-}:/repo:/repo/src:/repo/flask_city_council"
 
             # 6) Запуск тестов с покрытием (по возможности)
             #    Если tests/ есть — используем его как цель, иначе пустим pytest по умолчанию.


### PR DESCRIPTION
## Summary
- guard the Jenkins Pytest stage PYTHONPATH export so it works even when the variable is unset
- ensure the Jenkins Pytest fallback dependencies include pytest-cov so coverage options are recognized

## Testing
- not run (network restrictions blocked dependency installation)


------
https://chatgpt.com/codex/tasks/task_b_68f8cc9103fc832e9189b1019ca94908