### PR TITLE
Clarify Jenkins Pytest handling when tests missing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,10 @@ pipeline {
     stage('Tests: Pytest') {
       steps {
         sh '''
-          docker run --rm -v "$PWD":/repo -w /repo python:3.11-slim bash -lc '
+          docker run --rm \
+            -e GIT_BRANCH="${GIT_BRANCH:-}" \
+            -e GIT_COMMIT="${GIT_COMMIT:-}" \
+            -v "$PWD":/repo -w /repo python:3.11-slim bash -lc '
             set -euo pipefail
 
             # 1) Виртуалка для тестов
@@ -85,7 +88,7 @@ pipeline {
             if [ -f requirements.txt ]; then
               pip install --no-cache-dir -r requirements.txt
             else
-              pip install --no-cache-dir pytest pytest-flask coverage
+              pip install --no-cache-dir pytest pytest-flask pytest-cov coverage
             fi
 
             # 3) Динамически формируем список пакетов/каталогов для покрытия
@@ -96,18 +99,38 @@ pipeline {
 
             # 4) Если нет каталога tests — дадим предупреждение (pytest всё равно попытается найти тесты)
             if [ ! -d tests ]; then
-              echo "⚠️  Директория tests/ не найдена — pytest запустится по умолчанию."
+              echo "❌ Директория tests/ отсутствует в рабочем каталоге."
+              echo "   Текущая ветка: ${GIT_BRANCH:-неизвестно}" 
+              echo "   Коммит: ${GIT_COMMIT:-неизвестно}"
+              echo "   Убедитесь, что в этой ветке репозитория закоммичена папка tests/."
+              exit 1
             fi
 
             # 5) PYTHONPATH, чтобы импорты из подкаталогов находились
-            export PYTHONPATH="$PYTHONPATH:/repo:/repo/src:/repo/flask_city_council"
+            export PYTHONPATH="${PYTHONPATH:-}:/repo:/repo/src:/repo/flask_city_council"
 
             # 6) Запуск тестов с покрытием (по возможности)
             #    Если tests/ есть — используем его как цель, иначе пустим pytest по умолчанию.
             TARGET="tests"
             [ -d tests ] || TARGET="."
 
+            set +e
             pytest --maxfail=1 --disable-warnings "${COVARGS[@]}" --cov-report=term-missing "$TARGET"
+            RC=$?
+            set -e
+
+            case "$RC" in
+              0)
+                ;;
+              5)
+                echo "❌ Pytest вернул код 5 — тесты не были собраны."
+                echo "   Проверьте, что папка tests/ содержит файлы test_*.py и не исключена настройками pytest."
+                exit 5
+                ;;
+              *)
+                exit "$RC"
+                ;;
+            esac
           '
         '''
       }


### PR DESCRIPTION
## Summary
- pass branch and commit metadata into the Jenkins Pytest container for better context
- fail fast with a clear message when the tests/ directory is absent in the checkout
- report pytest exit code 5 with actionable guidance instead of continuing silently

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68f8cc9103fc832e9189b1019ca94908