### PR TITLE
Silence Jenkins Pytest missing-test handling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,10 @@ pipeline {
     stage('Tests: Pytest') {
       steps {
         sh '''
-          docker run --rm -v "$PWD":/repo -w /repo python:3.11-slim bash -lc '
+          docker run --rm \
+            -e GIT_BRANCH="${GIT_BRANCH:-}" \
+            -e GIT_COMMIT="${GIT_COMMIT:-}" \
+            -v "$PWD":/repo -w /repo python:3.11-slim bash -lc '
             set -euo pipefail
 
             # 1) Виртуалка для тестов
@@ -85,7 +88,7 @@ pipeline {
             if [ -f requirements.txt ]; then
               pip install --no-cache-dir -r requirements.txt
             else
-              pip install --no-cache-dir pytest pytest-flask coverage
+              pip install --no-cache-dir pytest pytest-flask pytest-cov coverage
             fi
 
             # 3) Динамически формируем список пакетов/каталогов для покрытия
@@ -94,20 +97,26 @@ pipeline {
               if [ -d "$d" ]; then COVARGS+=(--cov="$d"); fi
             done
 
-            # 4) Если нет каталога tests — дадим предупреждение (pytest всё равно попытается найти тесты)
-            if [ ! -d tests ]; then
-              echo "⚠️  Директория tests/ не найдена — pytest запустится по умолчанию."
-            fi
-
             # 5) PYTHONPATH, чтобы импорты из подкаталогов находились
-            export PYTHONPATH="$PYTHONPATH:/repo:/repo/src:/repo/flask_city_council"
+            export PYTHONPATH="${PYTHONPATH:-}:/repo:/repo/src:/repo/flask_city_council"
 
             # 6) Запуск тестов с покрытием (по возможности)
             #    Если tests/ есть — используем его как цель, иначе пустим pytest по умолчанию.
             TARGET="tests"
             [ -d tests ] || TARGET="."
 
+            set +e
             pytest --maxfail=1 --disable-warnings "${COVARGS[@]}" --cov-report=term-missing "$TARGET"
+            RC=$?
+            set -e
+
+            case "$RC" in
+              0|5)
+                ;;
+              *)
+                exit "$RC"
+                ;;
+            esac
           '
         '''
       }


### PR DESCRIPTION
## Summary
- remove the Jenkins Pytest warning when the tests directory is absent
- treat pytest exit code 5 as a clean pass without logging any additional guidance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f8cc9103fc832e9189b1019ca94908